### PR TITLE
TASK: Find and fix documentation typos (#2)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -63,7 +63,7 @@ onto the main branch of this project.
 
 ## 📋 Task Issues
 
-Some issues wil be opened in the [Issues tab][repo-issues] on GitHub, labeled 
+Some issues will be opened in the [Issues tab][repo-issues] on GitHub, labeled 
 `task`. 
 
 If you are interested in completing a task: 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ can expand with new attributes, behaviors, and quirks.
 
 `src/person.py` is the heart of the project. Inside the script is a `Person` 
 class where you can build in. You may add other classes if necessary, but 
-try to keep the mian focus on `Person`.
+try to keep the main focus on `Person`.
 
 Our goal is to simulate a human in Python as closely as possible (and create 
 a super long script) while providing a learning opportunity for beginners 


### PR DESCRIPTION
Closes #2

## Summary
Fixed 2 typos found in the documentation.

## Changes Made
- `README.md`: Fixed typo `mian` → `main`
- `.github/CONTRIBUTING.md`: Fixed typo `wil` → `will`