### PR TITLE
TASK: Update dates to use `datetime.date` type (#25)

### DIFF
--- a/src/person.py
+++ b/src/person.py
@@ -74,7 +74,7 @@ class Person:
 
         Raises:
             AttributeError: If the celebration day attribute does not exist.
-            TypeError: If the celebration date attribute is not a datetime or
+            TypeError: If the celebration date attribute is not a date or
                        is None.
         """
         if not isinstance(day, str):


### PR DESCRIPTION
changed the date types from datetime to date in Person.__init__ since we only care about dates not times. updated the type hints and the docstring in celebrate() too.

makes more sense since birthdays, anniversaries etc are just dates without specific times.

let me know if i missed anything!