### PR TITLE
TASK: Add `Person.write()` (#100)

### DIFF
--- a/theperson/person.py
+++ b/theperson/person.py
@@ -404,7 +404,7 @@ class Person:
 
         Args:
             contents: The content to be written, converted to str.
-            file: A text I/O stream with a write(str) method.
+            file: A text I/O stream with a 'write(str)' method.
 
         Raises:
             TypeError: If file has no callable write method.

--- a/theperson/person.py
+++ b/theperson/person.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import random
 import time
-from typing import Any, Sequence
+from typing import Any, Sequence, IO
 from datetime import date
 from dataclasses import dataclass, field
 
@@ -398,3 +398,23 @@ class Person:
             name=target.profile.name
         )
         
+    @staticmethod
+    def write(contents: object, file: IO[str]) -> None:
+        """Write contents to a text file-like object.
+
+        Args:
+            contents: The content to be written, converted to str.
+            file: A text I/O stream with a write(str) method.
+
+        Raises:
+            TypeError: If file has no callable write method.
+        """
+        write_method = getattr(file, "write", None)
+
+        if write_method is None or not callable(write_method):
+            raise TypeError(
+                "file must be a writable object with a write(str) method, "
+                f"got {type(file).__name__}"
+            )
+
+        file.write(str(contents))


### PR DESCRIPTION
## Changes
Adds a `Person.write()` static method that writes content to any text file-like object.

## Behaviour
- Accepts any object as `contents` and converts to `str` before writing
- Accepts any writable text I/O stream
- Raises `TypeError` if the `file` argument has no callable `write` method

Closes #100